### PR TITLE
Update install command in README

### DIFF
--- a/charts/tekton-dashboard/README.md
+++ b/charts/tekton-dashboard/README.md
@@ -4,7 +4,7 @@
 First add the Jenkins X chart repository
 
 ```sh
-helm repo add jxgh https://jenkins-x.github.io/tekton-dashboard-helm-chart/
+helm repo add jxtkn https://jenkins-x.github.io/tekton-dashboard-helm-chart/
 ```
 If it already exists be sure to update the local cache
 ```
@@ -13,5 +13,5 @@ helm repo update
 
 ## Basic install
 ```
-helm upgrade --install tekton-dashboard jxgh/tekton-dashboard-helm-chart
+helm upgrade --install tekton-dashboard jxtkn/tekton-dashboard
 ```


### PR DESCRIPTION
The following command is currently resulting in an error:


`helm upgrade --install tekton-dashboard jxgh/tekton-dashboard-helm-chart
`
`Error: chart "tekton-dashboard-helm-chart" matching not found in jxgh index. (try 'helm repo update'): no chart name found`
To resolve this issue and install the chart successfully, the command should be updated as follows:

`helm upgrade --install tekton-dashboard jxtkn/tekton-dashboard`
This ensures that the correct chart is referenced for installation.