### PR TITLE
Fix macos only chart update cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RESOURCE_YAML := ${CHART_DIR}/templates/resource.yaml
 
 CHART_REPO := gs://jenkinsxio/charts
 
-fetch:
+prep:
 	rm -f ${CHART_DIR}/templates/*.yaml
 	mkdir -p ${CHART_DIR}/templates
 ifeq ($(CHART_VERSION),latest)
@@ -31,9 +31,10 @@ endif
 	rm -f ${RESOURCE_YAML} args.yaml
   # Copy src templates
 	cp src/templates/* ${CHART_DIR}/templates
-ifneq ($(CHART_VERSION),latest)
-	sed -i "" -e "s/^appVersion:.*/appVersion: ${CHART_VERSION}/" ${CHART_DIR}/Chart.yaml
-endif
+
+fetch: prep
+  # Set value in Chart.yaml
+	yq eval -i '.appVersion = "$(shell yq eval '.data.version | sub("v"; "")' ${CHART_DIR}/templates/dashboard-info-cm.yaml)"' ${CHART_DIR}/Chart.yaml
 
 build:
 	rm -rf Chart.lock

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RESOURCE_YAML := ${CHART_DIR}/templates/resource.yaml
 
 CHART_REPO := gs://jenkinsxio/charts
 
-prep:
+fetch:
 	rm -f ${CHART_DIR}/templates/*.yaml
 	mkdir -p ${CHART_DIR}/templates
 ifeq ($(CHART_VERSION),latest)
@@ -31,10 +31,8 @@ endif
 	rm -f ${RESOURCE_YAML} args.yaml
   # Copy src templates
 	cp src/templates/* ${CHART_DIR}/templates
-
-fetch: prep
   # Set value in Chart.yaml
-	yq eval -i '.appVersion = "$(shell yq eval '.data.version | sub("v"; "")' ${CHART_DIR}/templates/dashboard-info-cm.yaml)"' ${CHART_DIR}/Chart.yaml
+	yq eval -i '.appVersion = (load("$(CHART_DIR)/templates/dashboard-info-cm.yaml").data.version | sub("v"; ""))' ${CHART_DIR}/Chart.yaml
 
 build:
 	rm -rf Chart.lock

--- a/charts/tekton-dashboard/Chart.yaml
+++ b/charts/tekton-dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Tekton Pipelines Dashboard
 name: tekton-dashboard
 version: 0.1.1
-appVersion: 0.35.0
+appVersion: "0.35.0"
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/jenkins-x/tekton-dashboard-helm-chart
 dependencies:


### PR DESCRIPTION
The makefile sed cmd to update Chart.yaml only worked on macos.. (sed -i ""...)

Slightly changed direction.. I've taken the version value from a file created from the split manifest.. We have no need to check for "latest" in that sense.

Added a target due to some makefile conformity.. Resulting version update to the Charts.yaml file has dbl quotes in the value.