### PR TITLE
feat: update tekton-dashboard to latest (v0.61.0)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.13.7
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ To fetch a specific version (say 0.32.0), use CHART_VERSION
 make CHART_VERSION=0.32.0 fetch
 ```
 
-Also, remember to change the `version` in `charts/tekton-dashboard/Chart.yaml`.
-The `app_version` will be set to the `CHART_VERSION` automatically by the makefile if a `CHART_VERSION` is specified.
-For latest set `app_version` to the latest tekton version from the [tekton release page](https://github.com/tektoncd/dashboard/releases) and not `latest`.
+#### Versioning
+`appVersion` is automatically set during the `make fetch` process. Set as the version pulled from Tekton.
+
+`chartVersion` is automatically set during the [publish workflow](.github/workflows/publish.yml). Set based on the semantic commits within the causal PR.
 
 ### Other use cases
 

--- a/charts/tekton-dashboard/Chart.yaml
+++ b/charts/tekton-dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Tekton Pipelines Dashboard
 name: tekton-dashboard
 version: 0.1.2
-appVersion: "0.35.0"
+appVersion: "0.61.0"
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/jenkins-x/tekton-dashboard-helm-chart
 dependencies:

--- a/charts/tekton-dashboard/templates/dashboard-info-cm.yaml
+++ b/charts/tekton-dashboard/templates/dashboard-info-cm.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  version: v0.35.0
+  version: v0.61.0
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/tekton-dashboard/templates/extensions.dashboard.tekton.dev-crd.yaml
+++ b/charts/tekton-dashboard/templates/extensions.dashboard.tekton.dev-crd.yaml
@@ -27,7 +27,7 @@ spec:
         - jsonPath: .spec.name
           name: Kind
           type: string
-        - jsonPath: .spec.displayname
+        - jsonPath: .spec.displayName
           name: Display name
           type: string
         - jsonPath: .metadata.creationTimestamp

--- a/charts/tekton-dashboard/templates/tekton-dashboard-backend-edit-clusterrole.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-backend-edit-clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-backend-edit
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dashboard.tekton.dev
+    resources:
+      - extensions
+    verbs:
+      - create
+      - update
+      - delete
+      - patch

--- a/charts/tekton-dashboard/templates/tekton-dashboard-backend-view-clusterrole.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-backend-view-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
-  name: tekton-dashboard-backend
+  name: tekton-dashboard-backend-view
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -20,20 +20,3 @@ rules:
       - securitycontextconstraints
     verbs:
       - use
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - clustertasks
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - triggers.tekton.dev
-    resources:
-      - clusterinterceptors
-      - clustertriggerbindings
-    verbs:
-      - get
-      - list
-      - watch

--- a/charts/tekton-dashboard/templates/tekton-dashboard-backend-view-crb.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-backend-view-crb.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
+  name: tekton-dashboard-backend-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-backend-view
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: '{{ .Release.Namespace }}'

--- a/charts/tekton-dashboard/templates/tekton-dashboard-deploy.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-deploy.yaml
@@ -7,9 +7,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: dashboard
     app.kubernetes.io/part-of: tekton-dashboard
-    app.kubernetes.io/version: v0.35.0
-    dashboard.tekton.dev/release: v0.35.0
-    version: v0.35.0
+    app.kubernetes.io/version: v0.61.0
+    dashboard.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tekton-dashboard
 spec:
   replicas: 1
@@ -27,9 +27,29 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/part-of: tekton-dashboard
-        app.kubernetes.io/version: v0.35.0
+        app.kubernetes.io/version: v0.61.0
       name: tekton-dashboard
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: dashboard
+                  app.kubernetes.io/instance: default
+                  app.kubernetes.io/name: dashboard
+                  app.kubernetes.io/part-of: tekton-dashboard
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
             {{- range $key, $value := .Values.args }}
@@ -40,7 +60,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard:v0.35.0@sha256:057471aa317c900e30178d64d83fc9d32cf2fcd718632243f7b902403b64981b
+        image: ghcr.io/tektoncd/dashboard/dashboard-9623576a202fe86c8b7d1bc489905f86:v0.61.0@sha256:32c8bb482129b42c5b09a29b34140aed53dc3ade1d7e24fef7a194075d1c87c7
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/tekton-dashboard/templates/tekton-dashboard-pipelines-view-crb.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-pipelines-view-crb.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-dashboard
+    rbac.dashboard.tekton.dev/subject: tekton-dashboard
+  name: tekton-dashboard-pipelines-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-aggregate-view
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: '{{ .Release.Namespace }}'

--- a/charts/tekton-dashboard/templates/tekton-dashboard-svc.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-svc.yaml
@@ -7,9 +7,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: dashboard
     app.kubernetes.io/part-of: tekton-dashboard
-    app.kubernetes.io/version: v0.35.0
-    dashboard.tekton.dev/release: v0.35.0
-    version: v0.35.0
+    app.kubernetes.io/version: v0.61.0
+    dashboard.tekton.dev/release: v0.61.0
+    version: v0.61.0
   name: tekton-dashboard
 spec:
   ports:

--- a/charts/tekton-dashboard/templates/tekton-dashboard-tenant-view-clusterrole.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-tenant-view-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: dashboard
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
-  name: tekton-dashboard-tenant
+  name: tekton-dashboard-tenant-view
 rules:
   - apiGroups:
       - dashboard.tekton.dev
@@ -22,30 +22,6 @@ rules:
       - namespaces
       - pods
       - pods/log
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - tasks
-      - taskruns
-      - pipelines
-      - pipelineruns
-      - customruns
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - triggers.tekton.dev
-    resources:
-      - eventlisteners
-      - interceptors
-      - triggerbindings
-      - triggers
-      - triggertemplates
     verbs:
       - get
       - list

--- a/charts/tekton-dashboard/templates/tekton-dashboard-tenant-view-crb.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-tenant-view-crb.yaml
@@ -6,11 +6,11 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
     rbac.dashboard.tekton.dev/subject: tekton-dashboard
-  name: tekton-dashboard-backend
+  name: tekton-dashboard-tenant-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-dashboard-backend
+  name: tekton-dashboard-tenant-view
 subjects:
   - kind: ServiceAccount
     name: tekton-dashboard

--- a/charts/tekton-dashboard/templates/tekton-dashboard-triggers-view-crb.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-triggers-view-crb.yaml
@@ -6,11 +6,11 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
     rbac.dashboard.tekton.dev/subject: tekton-dashboard
-  name: tekton-dashboard-tenant
+  name: tekton-dashboard-triggers-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-dashboard-tenant
+  name: tekton-triggers-aggregate-view
 subjects:
   - kind: ServiceAccount
     name: tekton-dashboard

--- a/charts/tekton-dashboard/values.yaml
+++ b/charts/tekton-dashboard/values.yaml
@@ -42,13 +42,14 @@ oauth2-proxy:
         secretName: example.com
 # args passed to the dashboard container
 args:
-  port: "9097"
-  logout-url: ""
-  pipelines-namespace: tekton-pipelines
-  triggers-namespace: tekton-pipelines
-  read-only: "true"
-  log-level: info
-  log-format: json
-  namespace: ""
-  stream-logs: "true"
+  default-namespace: ""
   external-logs: ""
+  log-format: json
+  log-level: info
+  logout-url: ""
+  namespaces: ""
+  pipelines-namespace: tekton-pipelines
+  port: "9097"
+  read-only: "true"
+  stream-logs: "true"
+  triggers-namespace: tekton-pipelines


### PR DESCRIPTION
Updating version of tekton dashboard to latest (v0.61.0) as jx now supports the versions of tekton-pipelines that tekton-dashboard is tested against (https://github.com/tektoncd/dashboard/blob/v0.61.0/test/e2e-tests.sh#L118-L120).

Also updated:
- python version in linter as workflow was failing
- README to reflect the actual versioning process
